### PR TITLE
🚑️ Forward client routing in production

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 import express from 'express';
+import path from 'path';
 
 const { PORT = 3000 } = process.env;
 
@@ -15,6 +16,11 @@ app.use(express.static('dist/app'));
 
 app.get('/', (_req, res) => {
   res.send('Hello World!');
+});
+
+// Handle client routing, return all requests to the app
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'app/index.html'));
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
On production (Heroku deployment or npm start), it's not possible to directly go to routes like /register.
This pull request fixes this issue and forwards all routes to the client.